### PR TITLE
Altera regex de processo para ser mais generica

### DIFF
--- a/src/js/model/handler.js
+++ b/src/js/model/handler.js
@@ -5,7 +5,7 @@ const removeSubstrFromStr = (startIndex, endIndex, text) => {
 };
 
 export const getCards = (cardList) => {
-  const extractSEIInfoRegex = /^SEI\s{1,}(\d+.\d+(?:\/\d+){0,}(?:-\d+){0,}).{0,}$/gm;
+  const extractSEIInfoRegex = /^SEI\s+((?:\d+[./-]?)+)/gm;
   let cards = [];
   cardList.forEach((cardFromTrello) => {
     let match = null;


### PR DESCRIPTION
O numero SEI assim como CNJ (área jurídica) pode ter pequenas variações ao longo dos anos, e por isso ter uma regex mais genérica pode ajudar a identificar mais facilmente. A regex anterior não funcionava no SEI de Minas.

O que a regex proposta faz:
`/^SEI\s+((?:\d+[./-]?)+)/gm`

- Linha iniciada com SEI seguida de 1 ou mais espaços
- Sequencia de sequencia numérica seguida de `./-`(opcional)
- Fim de linha

Qualquer dúvida estou à disposição